### PR TITLE
Fix: bitnami images stopped working

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Skip this step if you already have a kubernetes cluster with required addons.
 
 ```bash
 helm repo add naomi_charts https://copandrej.github.io/NAOMI/
-helm install naomi naomi_charts/NAOMI --version 0.3.1 --values values_example.yaml -n your_namespace
+helm install naomi naomi_charts/NAOMI --version 0.3.2 --values values_example.yaml -n your_namespace
 ```
 > [!IMPORTANT]
 > Helm version should be between 3.14 and 3.17

--- a/helm_charts/NAOMI/Chart.lock
+++ b/helm_charts/NAOMI/Chart.lock
@@ -15,4 +15,4 @@ dependencies:
   repository: https://prometheus-community.github.io/helm-charts
   version: 76.4.1
 digest: sha256:85b5c9d260a7e1577ba5795f1aefca8fe355d46e75010cb5853415085e872b47
-generated: "2025-09-30T11:39:32.189393351+02:00"
+generated: "2025-10-01T15:08:58.906804961+02:00"

--- a/helm_charts/NAOMI/Chart.yaml
+++ b/helm_charts/NAOMI/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: NAOMI
 description: NAOMI Helm chart for Kubernetes
 type: application
-version: 0.3.1
-appVersion: "0.3.1"
+version: 0.3.2
+appVersion: "0.3.2"
 
 dependencies:
 - condition: mlflow.enabled

--- a/helm_charts/NAOMI/values.yaml
+++ b/helm_charts/NAOMI/values.yaml
@@ -74,6 +74,17 @@ kuberay-operator:
 ################################################
 mlflow:
   enabled: true
+  image:
+    repository: bitnamilegacy/mlflow # Fix for bitnami deprecating support for their docker images https://github.com/bitnami/charts/issues/35164
+  volumePermissions:
+    image:
+      repository: bitnamilegacy/os-shell
+  waitContainer:
+    image:
+      repository: bitnamilegacy/os-shell
+  gitImage:
+    image:
+      repository: bitnamilegacy/git
   tracking:
     auth:
       enabled: false
@@ -105,6 +116,8 @@ mlflow:
       service:
         ports:
           postgresql: 5430
+    image:
+      repository: bitnamilegacy/postgresql 
 
 #################################################
 #
@@ -115,6 +128,8 @@ mlflow:
 
 minio:
   enabled: true
+  image:
+    repository: bitnamilegacy/minio # Fix for bitnami deprecating support for their docker images https://github.com/bitnami/charts/issues/35164
   service:
     type: NodePort
     ports:


### PR DESCRIPTION
Bitnami deprecated their free docker images so NAOMI stopped working. Fixed by pointing to older legacy repository. 
https://github.com/bitnami/charts/issues/35164

@cfortuna 